### PR TITLE
Add support for newest checkpoint, fix attention prior

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -1190,8 +1190,8 @@ public:
             (*mCrossAttentionMask)->reshape(runtime::ITensor::makeShape({1, getEncoderOutputLen()}));
         }
         // Create array of booleans
-        bool* mask = new bool[getEncoderOutputLen()];
-        std::fill(mask, mask + getEncoderOutputLen(), false);
+        auto mask = std::make_unique<bool[]>(getEncoderOutputLen());
+        std::fill(mask.get(), mask.get() + getEncoderOutputLen(), false);
         auto focus = getAttentionPriorIdx();
         for (int i = std::max(0, focus - 1); i < std::min(focus + 6, getEncoderOutputLen()); i++) {
             if (!isAttentionPriorStuck(i)) {
@@ -1199,8 +1199,7 @@ public:
             }
         }
         // Copy array to tensor
-        manager.copy(mask, **mCrossAttentionMask, runtime::MemoryType::kCPU);
-        delete[] mask;
+        manager.copy(mask.get(), **mCrossAttentionMask, runtime::MemoryType::kCPU);
     }
 
     [[nodiscard]] TensorPtr getSkipCrossAttnBlocks() const
@@ -1803,8 +1802,7 @@ public:
 
     bool isAttentionPriorFinished() const
     {
-        bool isFinished = mAttentionPriorCounterCloseToEnd >= 20;
-        return isFinished;
+        return mAttentionPriorCounterCloseToEnd >= 20;
     }
 
     bool isAttentionPriorStuck(int i) const

--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -1183,6 +1183,15 @@ public:
         return mCrossAttentionMask.value_or(nullptr);
     }
 
+    void setFocusCrossAttentionMask(runtime::BufferManager const& manager, int size=3)
+    {
+        if (!mCrossAttentionMask.has_value()) {
+            mCrossAttentionMask = std::move(manager.emptyTensor(runtime::MemoryType::kGPU, nvinfer1::DataType::kBOOL));
+            (*mCrossAttentionMask)->reshape(runtime::ITensor::makeShape({1, getEncoderOutputLen()}));
+            manager.setMem(**mCrossAttentionMask, 1);
+        }
+    }
+
     [[nodiscard]] TensorPtr getSkipCrossAttnBlocks() const
     {
         return mSkipCrossAttnBlocks.value_or(nullptr);

--- a/cpp/tensorrt_llm/batch_manager/encoderBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/encoderBuffers.cpp
@@ -525,8 +525,9 @@ void EncoderBuffers::fill(
             auto const encoderOutputSlice = runtime::ITensor::slice(encoderOutput, offset, size);
             manager.copy(*llmReq->getEncoderOutput(), *encoderOutputSlice);
             offset += size;
-
-            inputLengthsAll.emplace_back(size);
+            // TODO: this is to ensure that EOS is included into cross-attention computation
+            // need to check if it has negative effect
+            inputLengthsAll.emplace_back(size + 1);
         }
     }
     manager.copy(inputLengthsAll.data(), *inputLengths);

--- a/cpp/tensorrt_llm/batch_manager/encoderBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/encoderBuffers.cpp
@@ -525,9 +525,7 @@ void EncoderBuffers::fill(
             auto const encoderOutputSlice = runtime::ITensor::slice(encoderOutput, offset, size);
             manager.copy(*llmReq->getEncoderOutput(), *encoderOutputSlice);
             offset += size;
-            // TODO: this is to ensure that EOS is included into cross-attention computation
-            // need to check if it has negative effect
-            inputLengthsAll.emplace_back(size + 1);
+            inputLengthsAll.emplace_back(size);
         }
     }
     manager.copy(inputLengthsAll.data(), *inputLengths);

--- a/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
@@ -1004,9 +1004,9 @@ void RuntimeBuffers::setAttentionPriorIdx(
 
     SizeType32 qOffset = 0;
     // set the focus for context requests based on last scores slice
-    for (SizeType32 i = 0; i < (SizeType32)contextRequests.size(); ++i) {
+    for (SizeType32 i = 0; i < static_cast<SizeType32>(contextRequests.size()); ++i) {
         SizeType32 kvOffset = 0;
-        for (SizeType32 j = 0; j < (SizeType32)contextRequests.size(); ++j) {
+        for (SizeType32 j = 0; j < static_cast<SizeType32>(contextRequests.size()); ++j) {
             auto const& llmReq = contextRequests[j];
             SizeType32 encoderOutputLen = llmReq->getEncoderOutputLen();
             if (i == j) {
@@ -1022,10 +1022,10 @@ void RuntimeBuffers::setAttentionPriorIdx(
 
     // for generation requests, there is no context,
     // but we need to find correct section in (b * encoder_output_len)
-    for (SizeType32 i = 0; i < (SizeType32)genRequests.size(); ++i) {
+    for (SizeType32 i = 0; i < static_cast<SizeType32>(genRequests.size()); ++i) {
         // skip the context
         SizeType32 kvOffset = totalContextEncoderOutputLen;
-        for (SizeType32 j = 0; j < (SizeType32)genRequests.size(); ++j) {
+        for (SizeType32 j = 0; j < static_cast<SizeType32>(genRequests.size()); ++j) {
             auto const& llmReq = genRequests[j];
             SizeType32 encoderOutputLen = llmReq->getEncoderOutputLen();
             if (i == j) {

--- a/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
@@ -1031,6 +1031,13 @@ void RuntimeBuffers::setAttentionPriorIdx(
             if (i == j) {
                 // find attnetion prior idx in range [prev_prior_idx; prev_prior_idx + 10]
                 SizeType32 prevPriorIdx = llmReq->getAttentionPriorIdx();
+                if (llmReq->isAttentionPriorStuck(prevPriorIdx) && prevPriorIdx < encoderOutputLen - 5) {
+                    // since scores are recomputed, the `prevPriorIdx` can be selected again,
+                    // despite been masked. we skip it if its a sink to avoid this.
+                    // we allow sink at the very end of the sequence, becase it will be taken care of by
+                    // end-of-sequence detection.
+                    prevPriorIdx++;
+                }
                 // ignore last 3 tokens, move strictly forward, look up to 10 tokens forward
                 SizeType32 prevPriorIdxEnd = std::min(prevPriorIdx + searchLength, encoderOutputLen - 3);
                 SizeType32 prevPriorIdxLen = prevPriorIdxEnd - prevPriorIdx;

--- a/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
@@ -934,6 +934,45 @@ static SizeType32 processScoresWithType(ITensor* scoresHost, SizeType32 prevPrio
     return maxScoreIdx;
 }
 
+/**
+ * Copies a slice of the `scores` tensor (device) to the provided host buffer, synchronises the
+ * CUDA stream, and returns the local index of the maximum element.
+ *
+ * The helper is kept `static` to allow inlining by the compiler while providing a single
+ * implementation that can be re-used across both context and generation request loops.
+ */
+static SizeType32 computeMaxScoreIdx(
+    const runtime::ITensor::SharedPtr& scores,
+    SizeType32 qOff, SizeType32 kvOff, SizeType32 len,
+    ITensor* scoresHost,
+    BufferManager const& manager, CudaStream const& stream)
+{
+    if (len == 0)
+    {
+        return 0;
+    }
+
+    // Slice the relevant section of scores from device memory
+    auto scoresSlice = ITensor::slice(scores, {qOff, kvOff}, len);
+
+    // Copy slice to host buffer (scoresHost has enough capacity but may be larger than `len`)
+    scoresHost->reshape(ITensor::makeShape({len}));
+    manager.copy(*scoresSlice, *scoresHost);
+    stream.synchronize();
+
+    // Determine the maximum-score index depending on the underlying data type
+    if (scores->getDataType() == nvinfer1::DataType::kFLOAT)
+    {
+        return processScoresWithType<float>(scoresHost, len);
+    }
+    else if (scores->getDataType() == nvinfer1::DataType::kHALF)
+    {
+        return processScoresWithType<half>(scoresHost, len);
+    }
+    TLLM_LOG_WARNING("Unsupported scores data type");
+    return 0;
+}
+
 void RuntimeBuffers::setAttentionPriorIdx(
     RequestVector const& contextRequests, RequestVector const& genRequests, TllmRuntime const& runtime)
 {
@@ -957,19 +996,29 @@ void RuntimeBuffers::setAttentionPriorIdx(
         totalEncoderOutputLen += llmReq->getEncoderOutputLen();
     }
 
-    SizeType32 qOffset = 0;
-    // we skip all context requests
-    for (auto const& llmReq : contextRequests) {
-        qOffset += llmReq->getContextChunkSize();
-        // for context we just focusing at the beginning of the encoder sequence
-        llmReq->setAttentionPriorIdx(0);
-    }
-
     // create a cpu buffer for scores to find max score in
-    SizeType32 searchLength = 5;
+    SizeType32 searchLength = 10;
     auto const& manager = runtime.getBufferManager();
     auto const& stream = runtime.getStream();
     auto scoresHost = manager.cpu(ITensor::makeShape({searchLength}), scores->getDataType());
+
+    SizeType32 qOffset = 0;
+    // set the focus for context requests based on last scores slice
+    for (SizeType32 i = 0; i < (SizeType32)contextRequests.size(); ++i) {
+        SizeType32 kvOffset = 0;
+        for (SizeType32 j = 0; j < (SizeType32)contextRequests.size(); ++j) {
+            auto const& llmReq = contextRequests[j];
+            SizeType32 encoderOutputLen = llmReq->getEncoderOutputLen();
+            if (i == j) {
+                auto const& llmReq = contextRequests[j];
+                SizeType32 prevPriorIdxLen = std::min(searchLength, encoderOutputLen - 3);
+                SizeType32 maxIdx = computeMaxScoreIdx(scores, qOffset, kvOffset, prevPriorIdxLen, scoresHost.get(), manager, stream);
+                llmReq->setAttentionPriorIdx(maxIdx);
+            }
+            kvOffset += encoderOutputLen;
+        }
+        qOffset += contextRequests[i]->getContextChunkSize();
+    }
 
     // for generation requests, there is no context,
     // but we need to find correct section in (b * encoder_output_len)
@@ -983,28 +1032,10 @@ void RuntimeBuffers::setAttentionPriorIdx(
                 // find attnetion prior idx in range [prev_prior_idx; prev_prior_idx + 10]
                 SizeType32 prevPriorIdx = llmReq->getAttentionPriorIdx();
                 // ignore last 3 tokens, move strictly forward, look up to 10 tokens forward
-                SizeType32 prevPriorIdxEnd = std::min(prevPriorIdx + searchLength, encoderOutputLen);
+                SizeType32 prevPriorIdxEnd = std::min(prevPriorIdx + searchLength, encoderOutputLen - 3);
                 SizeType32 prevPriorIdxLen = prevPriorIdxEnd - prevPriorIdx;
-
-                // slice relevant section of scores
-                auto scoresSlice = ITensor::slice(scores, {qOffset, kvOffset + prevPriorIdx}, prevPriorIdxLen);
-                // copies and converts to float
-                scoresHost->reshape(ITensor::makeShape({prevPriorIdxLen}));
-                manager.copy(*scoresSlice, *scoresHost);
-                stream.synchronize();
-
-                // find index of maximum score in the window
-                SizeType32 maxScoreIdx = 0;
-                if (scores->getDataType() == nvinfer1::DataType::kFLOAT) {
-                    maxScoreIdx = processScoresWithType<float>(scoresHost.get(), prevPriorIdxLen);
-                } else if (scores->getDataType() == nvinfer1::DataType::kHALF) {
-                    maxScoreIdx = processScoresWithType<half>(scoresHost.get(), prevPriorIdxLen);
-                } else {
-                    TLLM_LOG_WARNING("Unsupported scores data type");
-                }
-
-                // Set the attention prior index to the position with maximum score
-                llmReq->setAttentionPriorIdx(prevPriorIdx + maxScoreIdx);
+                SizeType32 maxIdx = computeMaxScoreIdx(scores, qOffset, kvOffset + prevPriorIdx, prevPriorIdxLen, scoresHost.get(), manager, stream);
+                llmReq->setAttentionPriorIdx(prevPriorIdx + maxIdx);
             }
             kvOffset += encoderOutputLen;
         }

--- a/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
@@ -966,7 +966,7 @@ void RuntimeBuffers::setAttentionPriorIdx(
     }
 
     // create a cpu buffer for scores to find max score in
-    SizeType32 searchLength = 10;
+    SizeType32 searchLength = 5;
     auto const& manager = runtime.getBufferManager();
     auto const& stream = runtime.getStream();
     auto scoresHost = manager.cpu(ITensor::makeShape({searchLength}), scores->getDataType());

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -2287,7 +2287,8 @@ void TrtGptModelInflightBatching::updateRequests(ScheduledRequests const& schedu
 
             // Terminate if request has finished or if it is speculative decoding target model
             if (decoderFinishedSumPtr[seqSlot] == reqBeamWidth
-                || (mModelConfig.getSpeculativeDecodingMode().isDraftTokensExternal() && llmReq->hasDraftTokens()))
+                || (mModelConfig.getSpeculativeDecodingMode().isDraftTokensExternal() && llmReq->hasDraftTokens())
+                || (mModelConfig.useAttentionPrior() && llmReq->isAttentionPriorFinished()))
             {
                 postProcessRequest(*llmReq, numDroppedTokens);
 

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderMaskedMultiheadAttentionTemplate.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderMaskedMultiheadAttentionTemplate.h
@@ -1511,10 +1511,9 @@ __global__ void __launch_bounds__(MAX_THEADS_PER_BLOCK, MIN_BLOCKS_PER_SM) maske
         = params.relative_attention_bias_stride; // num_buckets might be modified below, save it beforehand
     [[maybe_unused]] int max_distance = params.max_distance;
 
-    // The actual sequence length excluding the paddings.
-    // minus 1 because it includes the current timestep while tlength denotes the kv cache length.
+    // Keep the EOS token for cross attention to attend to.
     int const tlength = DO_CROSS_ATTENTION
-        ? params.memory_length_per_sample[batch_beam_idx] - 1
+        ? params.memory_length_per_sample[batch_beam_idx]
         : (params.length_per_sample ? (params.length_per_sample[batch_beam_idx] - 1) : static_cast<int>(timestep));
     // We will use cyclic kv cache when it exceeds the limit.
     // The length position for storing new key and value.

--- a/tensorrt_llm/models/t5tts/model.py
+++ b/tensorrt_llm/models/t5tts/model.py
@@ -51,7 +51,7 @@ mlp_map = {
     MLPType.FusedGatedMLP: FusedGatedMLP,
 }
 
-COMPUTE_SCORES_FROM_LAYERS = [4, 5]
+COMPUTE_SCORES_FROM_LAYERS = [4, 6, 10]
 
 
 class PositionwiseConvFF(Module):
@@ -470,7 +470,7 @@ class T5TTSDecoderLayer(Module):
             local_layer_idx=local_layer_idx,
             hidden_size=hidden_size,
             num_attention_heads=1,
-            attention_head_size=hidden_size,
+            attention_head_size=128,  # TODO: make this part of model config
             num_kv_heads=1,
             max_position_embeddings=max_position_embeddings,
             bias=has_attention_qkvo_bias,
@@ -570,10 +570,11 @@ class T5TTSDecoderLayer(Module):
         hidden_states = residual + attention_output
 
         # compute attention scores
-        # TODO: assumes padding disabled
+        # TODO: only implements disabled padding
+        # TODO: hardcodes head_size for cross attention
         if self.compute_scores:
-            q = slice(qkv, concat([0, 0]), concat([shape(qkv, 0), self.hidden_size]))
-            k = slice(cross_kv, concat([0, 0]), concat([shape(cross_kv, 0), self.hidden_size]))
+            q = slice(qkv, concat([0, 0]), concat([shape(qkv, 0), 128]))
+            k = slice(cross_kv, concat([0, 0]), concat([shape(cross_kv, 0), 128]))
             scores = matmul(
                 q,
                 k,


### PR DESCRIPTION
Changes to fix attention prior: actually use attention mask in attention kernel. Introduce support for newest checkpoint: some values are hardcoded, we should move them to config. Set inputLength to encoderLen + 1, because attention kernel attends only inputLength - 1 timesteps in kv sequence during cross attention. Currently we achieve CER comparable to NeMo, but the end of generation detection should be still improved.